### PR TITLE
Removing chrome=1

### DIFF
--- a/dotnet 4/mvc4 & mvc4api/web.config
+++ b/dotnet 4/mvc4 & mvc4api/web.config
@@ -230,7 +230,7 @@
                 github.com/rails/rails/commit/123eb25#commitcomment-118920
                 Use ChromeFrame if it's installed for a better experience for the poor IE folk
                 -->
-                <add name="X-UA-Compatible" value="IE=Edge,chrome=1" />
+                <add name="X-UA-Compatible" value="IE=Edge" />
                 <!--
                 Allow cookies to be set from iframes (for IE only)
                 If needed, uncomment and specify a path or regex in the Location directive


### PR DESCRIPTION
Since Chrome Frame is being discontinued, having chrome=1 is unnecessary.
