### PR TITLE
Updated link to Cachebusting discussion

### DIFF
--- a/dotnet 4.5/MVC5/Web.config
+++ b/dotnet 4.5/MVC5/Web.config
@@ -291,7 +291,7 @@
             /css/style.20110203.css to /css/style.css
 
             To understand why this is important and a better idea than all.css?v1231,
-            read: github.com/h5bp/html5-boilerplate/wiki/Version-Control-with-Cachebusting
+            read: http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/
 
                 <rule name="Cachebusting">
                     <match url="^(.+)\.\d+(\.(js|css|png|jpg|gif)$)" />


### PR DESCRIPTION
Link was broken. Found .htaccess stuff at https://github.com/h5bp/server-configs-apache/blob/master/src/web_performance/filename-based_cache_busting.conf which refers to Steve Souders' blog.
