### PR TITLE
Change existingResponse from PassThrough to Auto

### DIFF
--- a/dotnet 4.5/MVC5/Web.config
+++ b/dotnet 4.5/MVC5/Web.config
@@ -17,11 +17,11 @@
         <!-- Security through obscurity, removes  X-AspNet-Version HTTP header from the response -->
         <!-- Allow zombie DOS names to be captured by ASP.NET (/con, /com1, /lpt1, /aux, /prt, /nul, etc) -->
         <httpRuntime enableVersionHeader="false" relaxedUrlToFileSystemMapping="true" requestPathInvalidCharacters="" requestValidationMode="2.0" targetFramework="4.5"/>
-        <!-- httpCookies httpOnlyCookies setting defines whether cookies 
+        <!-- httpCookies httpOnlyCookies setting defines whether cookies
              should be exposed to client side scripts
              false (Default): client side code can access cookies
              true: client side code cannot access cookies
-             Require SSL is situational, you can also define the 
+             Require SSL is situational, you can also define the
              domain of cookies with optional "domain" property -->
         <httpCookies httpOnlyCookies="true" requireSSL="false"/>
         <trace enabled="false" localOnly="true" pageOutput="false" writeToDiagnosticsTrace="false"/>
@@ -38,7 +38,7 @@
                 <add enabled="false" mimeType="*/*"/>
             </staticTypes>
         </httpCompression>
-        <httpErrors errorMode="Custom" existingResponse="PassThrough">
+        <httpErrors errorMode="Custom">
             <!-- Catch IIS 404 error due to paths that exist but shouldn't be served (e.g. /controllers, /global.asax) or IIS request filtering (e.g. bin, web.config, app_code, app_globalresources, app_localresources, app_webreferences, app_data, app_browsers) -->
             <remove statusCode="404" subStatusCode="-1"/>
             <error path="/notfound" responseMode="ExecuteURL" statusCode="404" subStatusCode="-1"/>
@@ -170,10 +170,10 @@
                 If enabled, without 'mode=block', there is an increased risk that
                 otherwise non-exploitable cross-site scripting vulnerabilities may potentially become exploitable
                 <remove name="X-XSS-Protection" /><add name="X-XSS-Protection" value="1; mode=block"/>-->
-                <!--    
+                <!--
                 # MIME type sniffing security protection
                 Enabled by default as there are very few edge cases where you wouldn't want this enabled.
-                Theres additional reading below; but the tldr, it reduces the ability of the browser (mostly IE) 
+                Theres additional reading below; but the tldr, it reduces the ability of the browser (mostly IE)
                 being tricked into facilitating driveby attacks.
                 http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx
                 http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-v-comprehensive-protection.aspx
@@ -230,11 +230,11 @@
                 such as Varnish. http://en.wikipedia.org/wiki/HTTP_ETag / http://developer.yahoo.com/performance/rules.html#etags
                 But in load balancing and simply most cases ETags are mishandled in IIS; and it can be advantageous to remove them.
         # removed as in https://stackoverflow.com/questions/7947420/iis-7-5-remove-etag-headers-from-response
-        
+
         <rewrite><outboundRules><rule name="Remove ETag"><match serverVariable="RESPONSE_ETag" pattern=".+" /><action type="Rewrite" value="" /></rule></outboundRules></rewrite>-->
         <!--
             ### Built-in filename-based cache busting
-            
+
             In a managed language such as .net you should really be using the internal bundler for css + js
             or getCassette or  similar.
 


### PR DESCRIPTION
In ASP.NET MVC, PassThrough will serve a blank page when we serve a >4XX
response (e.g. using `return new HttpStatusCode(HttpStatusCode.Forbidden)`) even when a route is set for 403 errors. By reverting to Auto, the view will be correctly rendered.