### PR TITLE
Change existingResponse from PassThrough to Auto

### DIFF
--- a/dotnet 4.5/MVC5/Web.config
+++ b/dotnet 4.5/MVC5/Web.config
@@ -67,6 +67,9 @@
                 <add enabled="false" mimeType="*/*"/>
             </staticTypes>
         </httpCompression>
+        <!-- Settings httpErrors existingResponse will determine how 
+             IIS/ASP.NET handle HTTP 4XX/5XX responses 
+             http://stackoverflow.com/a/31041696/465056 -->
         <httpErrors errorMode="Custom">
             <!-- Catch IIS 404 error due to paths that exist but shouldn't be served (e.g. /controllers, /global.asax) or IIS request filtering (e.g. bin, web.config, app_code, app_globalresources, app_localresources, app_webreferences, app_data, app_browsers) -->
             <remove statusCode="404" subStatusCode="-1"/>

--- a/dotnet 4.5/MVC5/Web.config
+++ b/dotnet 4.5/MVC5/Web.config
@@ -67,7 +67,7 @@
                 <add enabled="false" mimeType="*/*"/>
             </staticTypes>
         </httpCompression>
-        <httpErrors errorMode="Custom" existingResponse="PassThrough">
+        <httpErrors errorMode="Custom">
             <!-- Catch IIS 404 error due to paths that exist but shouldn't be served (e.g. /controllers, /global.asax) or IIS request filtering (e.g. bin, web.config, app_code, app_globalresources, app_localresources, app_webreferences, app_data, app_browsers) -->
             <remove statusCode="404" subStatusCode="-1"/>
             <error path="/notfound" responseMode="ExecuteURL" statusCode="404" subStatusCode="-1"/>


### PR DESCRIPTION
In ASP.NET MVC, PassThrough will serve a blank page when we serve a >4XX
response (e.g. using return new HttpStatusCode(HttpStatusCode.Forbidden))
even when a route is set for 403 errors. By reverting to Auto, the view
will be correctly rendered.
