### PR TITLE
Increase max-age for HSTS to recommended default

### DIFF
--- a/dotnet 4.5/MVC5/Web.config
+++ b/dotnet 4.5/MVC5/Web.config
@@ -187,8 +187,7 @@
                 The HTTP Strict Transport Security header is used to control
                 if the browser is allowed to only access a site over a secure connection
                 and how long to remember the server response for, forcing continued usage.
-                Note* Currently a draft standard which only Firefox and Chrome support. But is supported by sites like PayPal.
-                <remove name="Strict-Transport-Security" /><add name="Strict-Transport-Security" value="max-age=15768000"/>-->
+                <remove name="Strict-Transport-Security" /><add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains"/>-->
                 <!--
                 # X-Frame-Options
                 The X-Frame-Options header indicates whether a browser should be allowed


### PR DESCRIPTION
HSTS is now supported by all the major browsers

http://caniuse.com/#search=Strict%20Transport%20Security