### PR TITLE
Add IIS compression for JsonResult in MVC

### DIFF
--- a/dotnet 4.5/MVC5/Web.config
+++ b/dotnet 4.5/MVC5/Web.config
@@ -57,6 +57,7 @@
 				<add enabled="true" mimeType="message/*" />
 				<add enabled="true" mimeType="application/javascript" />
 				<add enabled="true" mimeType="application/json" />
+				<add enabled="true" mimeType="application/json; charset=utf-8" />
 				<add enabled="false" mimeType="*/*" />
 			</dynamicTypes>
             <staticTypes>
@@ -64,6 +65,7 @@
                 <add enabled="true" mimeType="message/*"/>
                 <add enabled="true" mimeType="application/javascript"/>
                 <add enabled="true" mimeType="application/json"/>
+                <add enabled="true" mimeType="application/json; charset=utf-8" />
                 <add enabled="false" mimeType="*/*"/>
             </staticTypes>
         </httpCompression>


### PR DESCRIPTION
JsonResults in MVC returns a different MIME-TYPE than normal Json file.
IIS compression now works for it.